### PR TITLE
Remove *::-webkit-scrollbar* settings from CSS

### DIFF
--- a/css/a-table.css
+++ b/css/a-table.css
@@ -9,21 +9,6 @@
   padding-bottom: 2px;
 }
 
-.a-table-outer::-webkit-scrollbar {
-  width: 15px;
-  height: 1px;
-}
-
-.a-table-outer::-webkit-scrollbar-thumb {
-  border-radius: 8px;
-  background-color: #999999;
-}
-
-.a-table-outer::-webkit-scrollbar-track {
-  border-radius: 8px;
-  background-color: #ffffff;
-}
-
 .a-table-pseudo {
   position: absolute;
   top: 0;


### PR DESCRIPTION
The horizontal scrollbar is thin and hard to drag and move in this module.

If considering from information of mdn web docs, the current customed scrollbar looks not so good.
https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar#accessibility

I think it is better that scrollbars are customised in application CSS file by users need them.

Therefore, I propose to remove ::-webkit-scrollbar from CSS file.